### PR TITLE
earlgrey: rule-priority filter on parse forest (phase 4)

### DIFF
--- a/earlgrey/src/earley/parser_test.rs
+++ b/earlgrey/src/earley/parser_test.rs
@@ -544,6 +544,102 @@ fn eval_iter_is_fused_after_error() {
 }
 
 #[test]
+fn rule_priority_baseline_no_effect() {
+    // Without any priorities set, an ambiguous grammar enumerates the full
+    // forest exactly as before phase 4.
+    let grammar = GrammarBuilder::default()
+        .nonterm("E")
+        .terminal("+", |n| n == "+")
+        .terminal("n", |n| "1234567890".contains(n))
+        .rule("E", &["E", "+", "E"])
+        .rule("E", &["n"])
+        .into_grammar("E")
+        .expect("Bad grammar");
+    let p = EarleyParser::new(grammar.clone());
+    let pout = p.parse("0 + 1 + 2 + 3 + 4 + 5".split_whitespace()).unwrap();
+    let ef = tree_evaler(grammar);
+    assert_eq!(ef.eval_all(&pout).unwrap().len(), 42);
+}
+
+#[test]
+fn rule_priority_collapses_unmatched_paren() {
+    // expr -> int
+    //       | '(' expr ')'   @prio 10  (matched — winner)
+    //       | '(' expr       @prio 1   (unmatched open)
+    //       | expr ')'       @prio 1   (unmatched close)
+    // Input "( 1 )" has three derivations at the root; priorities collapse
+    // the forest to just the matched one.
+    let grammar = GrammarBuilder::default()
+        .nonterm("expr")
+        .terminal("(", |n| n == "(")
+        .terminal(")", |n| n == ")")
+        .terminal("int", |n| n.chars().all(|c| "0123456789".contains(c)))
+        .rule("expr", &["int"])
+        .rule("expr", &["(", "expr", ")"])
+        .rule("expr", &["(", "expr"])
+        .rule("expr", &["expr", ")"])
+        .into_grammar("expr")
+        .expect("Bad grammar");
+    let p = EarleyParser::new(grammar.clone());
+    let pout = p.parse("( 1 )".split_whitespace()).unwrap();
+
+    let ef_plain = tree_evaler(grammar.clone());
+    assert!(
+        ef_plain.eval_all(&pout).unwrap().len() >= 2,
+        "unmatched-paren grammar should be ambiguous without priorities"
+    );
+
+    let mut ef = tree_evaler(grammar);
+    ef.rule_priority("expr -> ( expr )", 10);
+    ef.rule_priority("expr -> ( expr", 1);
+    ef.rule_priority("expr -> expr )", 1);
+    assert_eq!(
+        ef.eval_all(&pout).unwrap().len(),
+        1,
+        "priorities should collapse unmatched-paren ambiguity to one tree"
+    );
+}
+
+#[test]
+fn rule_priority_filters_within_span() {
+    // S -> expr '$' is unambiguous at the top; ambiguity is one level deeper.
+    // Priorities attached to inner-`expr` rules must still collapse the forest
+    // by filtering Completion backpointers within the outer span.
+    let grammar = GrammarBuilder::default()
+        .nonterm("S")
+        .nonterm("expr")
+        .terminal("$", |n| n == "$")
+        .terminal("(", |n| n == "(")
+        .terminal(")", |n| n == ")")
+        .terminal("int", |n| n.chars().all(|c| "0123456789".contains(c)))
+        .rule("S", &["expr", "$"])
+        .rule("expr", &["int"])
+        .rule("expr", &["(", "expr", ")"])
+        .rule("expr", &["(", "expr"])
+        .rule("expr", &["expr", ")"])
+        .into_grammar("S")
+        .expect("Bad grammar");
+    let p = EarleyParser::new(grammar.clone());
+    let pout = p.parse("( 1 ) $".split_whitespace()).unwrap();
+
+    let ef_plain = tree_evaler(grammar.clone());
+    assert!(
+        ef_plain.eval_all(&pout).unwrap().len() >= 2,
+        "baseline should be ambiguous at the inner expr"
+    );
+
+    let mut ef = tree_evaler(grammar);
+    ef.rule_priority("expr -> ( expr )", 10);
+    ef.rule_priority("expr -> ( expr", 1);
+    ef.rule_priority("expr -> expr )", 1);
+    assert_eq!(
+        ef.eval_all(&pout).unwrap().len(),
+        1,
+        "within-span priority filter must collapse the inner ambiguity"
+    );
+}
+
+#[test]
 fn trigger_has_multiple_bp() {
     // E -> E + n | n + E | n
     // SpanSource::Completion has multiple sources.

--- a/earlgrey/src/earley/parser_test.rs
+++ b/earlgrey/src/earley/parser_test.rs
@@ -258,7 +258,17 @@ fn earley_bottomless() {
         &evaler.eval_all_recursive(&pout).unwrap(),
         expected_trees.clone(),
     );
-    // TODO: check_trees(&evaler.eval_all(&pout).unwrap(), expected_trees.clone());
+    // Phase 1b: iterative path has no cycle tracking yet, so it terminates
+    // with a typed error instead of panicking or looping. Phase 1a (future)
+    // will make this succeed like eval_all_recursive.
+    let err = evaler
+        .eval_all(&pout)
+        .expect_err("iterative eval_all should surface a bottomless-grammar error");
+    assert!(
+        err.contains("Bottomless grammar"),
+        "unexpected error: {}",
+        err
+    );
 }
 
 #[test]
@@ -399,6 +409,138 @@ fn math_ambiguous_catalan() {
     // https://en.wikipedia.org/wiki/Associahedron
     assert_eq!(ef.eval_all_recursive(&pout).unwrap().len(), 42);
     assert_eq!(ef.eval_all(&pout).unwrap().len(), 42);
+}
+
+#[test]
+fn eval_iter_take_stops_early() {
+    // E -> E + E | n, six operands → Catalan(5) = 42 trees.
+    // eval_iter.take(3) must yield exactly 3 trees without building the rest.
+    let grammar = GrammarBuilder::default()
+        .nonterm("E")
+        .terminal("+", |n| n == "+")
+        .terminal("n", |n| "1234567890".contains(n))
+        .rule("E", &["E", "+", "E"])
+        .rule("E", &["n"])
+        .into_grammar("E")
+        .expect("Bad grammar");
+    let p = EarleyParser::new(grammar.clone());
+    let pout = p.parse("0 + 1 + 2 + 3 + 4 + 5".split_whitespace()).unwrap();
+    let ef = tree_evaler(grammar);
+
+    let taken: Result<Vec<_>, _> = ef.eval_iter(&pout).take(3).collect();
+    assert_eq!(taken.unwrap().len(), 3);
+}
+
+#[test]
+fn eval_iter_matches_eval_all() {
+    // Iterator collected in full must match the eager eval_all output
+    // element-for-element on an ambiguous grammar.
+    let grammar = GrammarBuilder::default()
+        .nonterm("E")
+        .terminal("+", |n| n == "+")
+        .terminal("n", |n| "1234567890".contains(n))
+        .rule("E", &["E", "+", "E"])
+        .rule("E", &["n"])
+        .into_grammar("E")
+        .expect("Bad grammar");
+    let p = EarleyParser::new(grammar.clone());
+    let pout = p.parse("0 + 1 + 2 + 3".split_whitespace()).unwrap();
+    let ef = tree_evaler(grammar);
+
+    let eager = ef.eval_all(&pout).unwrap();
+    let lazy: Vec<_> = ef
+        .eval_iter(&pout)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(
+        eager.len(),
+        lazy.len(),
+        "eager and lazy tree counts differ"
+    );
+    for (a, b) in eager.iter().zip(lazy.iter()) {
+        assert_eq!(format!("{:?}", a), format!("{:?}", b));
+    }
+}
+
+#[test]
+fn eval_capped_returns_at_most_n() {
+    // Catalan(5) = 42 trees; cap at 5 and verify we get exactly 5.
+    let grammar = GrammarBuilder::default()
+        .nonterm("E")
+        .terminal("+", |n| n == "+")
+        .terminal("n", |n| "1234567890".contains(n))
+        .rule("E", &["E", "+", "E"])
+        .rule("E", &["n"])
+        .into_grammar("E")
+        .expect("Bad grammar");
+    let p = EarleyParser::new(grammar.clone());
+    let pout = p.parse("0 + 1 + 2 + 3 + 4 + 5".split_whitespace()).unwrap();
+    let ef = tree_evaler(grammar);
+
+    let capped = ef.eval_capped(&pout, 5).unwrap();
+    assert_eq!(capped.len(), 5);
+}
+
+#[test]
+fn max_steps_per_tree_triggers_error() {
+    // With a very tight step cap, even a well-formed parse should error
+    // out on the iterative walker. This exercises the configurable cap
+    // introduced in phase 3.
+    let grammar = GrammarBuilder::default()
+        .nonterm("E")
+        .terminal("+", |n| n == "+")
+        .terminal("n", |n| "1234567890".contains(n))
+        .rule("E", &["E", "+", "E"])
+        .rule("E", &["n"])
+        .into_grammar("E")
+        .expect("Bad grammar");
+    let p = EarleyParser::new(grammar.clone());
+    let pout = p.parse("0 + 1 + 2".split_whitespace()).unwrap();
+    let mut ef = tree_evaler(grammar);
+    ef.max_steps_per_tree(1);
+
+    let err = ef
+        .eval(&pout)
+        .expect_err("tight step cap should return Err");
+    assert!(
+        err.contains("max tree-walk steps"),
+        "unexpected error: {}",
+        err
+    );
+}
+
+#[test]
+fn eval_iter_is_fused_after_error() {
+    // Once an iteration returns Err, subsequent next() calls must yield None.
+    let grammar = GrammarBuilder::default()
+        .nonterm("E")
+        .nonterm("A")
+        .terminal("n", |n| n == "n")
+        .rule("E", &["A"])
+        .rule("A", &["E"])
+        .rule("A", &["n"])
+        .into_grammar("E")
+        .expect("Bad grammar");
+    let p = EarleyParser::new(grammar.clone());
+    let pout = p.parse("n".split_whitespace()).unwrap();
+    let ef = tree_evaler(grammar);
+
+    // The bottomless grammar can still yield a valid first tree (A -> n path);
+    // the Err surfaces once the iterator tries cyclic alternatives.
+    let mut iter = ef.eval_iter(&pout);
+    let mut found_err = false;
+    while let Some(r) = iter.next() {
+        if r.is_err() {
+            found_err = true;
+            break;
+        }
+    }
+    assert!(
+        found_err,
+        "expected at least one Err from the iterator on a bottomless grammar"
+    );
+    assert!(iter.next().is_none(), "iterator must be fused after Err");
+    assert!(iter.next().is_none(), "iterator must stay fused");
 }
 
 #[test]

--- a/earlgrey/src/earley/spans.rs
+++ b/earlgrey/src/earley/spans.rs
@@ -156,7 +156,7 @@ impl Span {
 
     /// Scans or Completions that led to the creation of this Span.
     /// Only ever borrowed non-mutable ref returned for public consumption
-    pub fn sources(&self) -> cell::Ref<Vec<SpanSource>> {
+    pub fn sources(&self) -> cell::Ref<'_, Vec<SpanSource>> {
         self.backpointers.borrow()
     }
 

--- a/earlgrey/src/earley/trees.rs
+++ b/earlgrey/src/earley/trees.rs
@@ -20,6 +20,10 @@ pub struct EarleyForest<'a, ASTNode: Clone> {
     // Per-tree walk step cap overriding MAX_EVAL_ONE_STEPS. `None` keeps
     // the built-in safety net; `Some(n)` lets callers tighten or relax it.
     max_steps_per_tree: Option<usize>,
+    // Per-rule priorities (keyed by canonical `"head -> sym1 sym2 ..."`).
+    // Unset rules default to 0. Higher wins when competing parses of the
+    // same constituent are both derivable.
+    priorities: HashMap<String, i32>,
 }
 
 impl<'a, ASTNode: Clone> EarleyForest<'a, ASTNode> {
@@ -28,6 +32,7 @@ impl<'a, ASTNode: Clone> EarleyForest<'a, ASTNode> {
             actions: HashMap::new(),
             terminal_parser: Box::new(terminal_parser),
             max_steps_per_tree: None,
+            priorities: HashMap::new(),
         }
     }
 
@@ -44,6 +49,73 @@ impl<'a, ASTNode: Clone> EarleyForest<'a, ASTNode> {
         self.max_steps_per_tree = Some(max);
         self
     }
+
+    /// Assign a priority to a rule by its canonical string form
+    /// (e.g. `"expr -> ( expr )"`). When competing parses of the same
+    /// constituent are derivable, only the highest-priority alternative
+    /// is enumerated. Unset rules share the default priority of 0.
+    pub fn rule_priority(&mut self, rule: &str, priority: i32) -> &mut Self {
+        self.priorities.insert(rule.to_string(), priority);
+        self
+    }
+}
+
+fn source_priority(src: &SpanSource, priorities: &HashMap<String, i32>) -> i32 {
+    match src {
+        // A Completion "picks" a child production — score it by the
+        // trigger's rule. `Scan` sources don't represent a rule choice,
+        // so they share the default priority.
+        SpanSource::Completion(_, trigger) => priorities
+            .get(&trigger.rule.to_string())
+            .copied()
+            .unwrap_or(0),
+        SpanSource::Scan(_, _) => 0,
+    }
+}
+
+fn eligible_source_indices(span: &Rc<Span>, priorities: &HashMap<String, i32>) -> Vec<usize> {
+    let sources = span.sources();
+    if sources.is_empty() {
+        return Vec::new();
+    }
+    if priorities.is_empty() {
+        return (0..sources.len()).collect();
+    }
+    let mut best: Option<i32> = None;
+    let mut scored: Vec<(usize, i32)> = Vec::with_capacity(sources.len());
+    for (idx, src) in sources.iter().enumerate() {
+        let p = source_priority(src, priorities);
+        best = Some(best.map_or(p, |b| b.max(p)));
+        scored.push((idx, p));
+    }
+    let best = best.unwrap();
+    scored
+        .into_iter()
+        .filter(|(_, p)| *p == best)
+        .map(|(i, _)| i)
+        .collect()
+}
+
+fn eligible_roots(
+    roots: &[Rc<Span>],
+    priorities: &HashMap<String, i32>,
+) -> Vec<Rc<Span>> {
+    if priorities.is_empty() || roots.is_empty() {
+        return roots.to_vec();
+    }
+    let mut best: Option<i32> = None;
+    let mut scored: Vec<(Rc<Span>, i32)> = Vec::with_capacity(roots.len());
+    for r in roots {
+        let p = priorities.get(&r.rule.to_string()).copied().unwrap_or(0);
+        best = Some(best.map_or(p, |b| b.max(p)));
+        scored.push((r.clone(), p));
+    }
+    let best = best.unwrap();
+    scored
+        .into_iter()
+        .filter(|(_, p)| *p == best)
+        .map(|(r, _)| r)
+        .collect()
 }
 
 impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
@@ -171,28 +243,35 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
 }
 
 struct ForestIterator {
-    // A stack of (span, current-source-idx).
-    // Each time the iterator is advanced we advance the source-idx for the top span.
-    // When that span exhausted all sources, we pop the top span. This results in a
-    // reset if it ever comes back from a different path. At the same time advance
-    // the new top-of-stack span. If this one is exhausted, then rinse, repeat.
-    source_idx: Vec<(Rc<Span>, usize)>,
+    // A stack of (span, position-in-eligible-list, cached-eligible-indices).
+    // `eligible` is the filtered subset of `span.sources()` indices that the
+    // priority filter retained — computed once per first-visit. `position`
+    // advances over `eligible`; the index fed to `eval_one` is
+    // `eligible[position]`. When `position + 1 == eligible.len()` the span
+    // is exhausted and gets popped during `advance`.
+    source_idx: Vec<(Rc<Span>, usize, Vec<usize>)>,
 }
 
 impl ForestIterator {
-    fn source_index(&mut self, cursor: &Rc<Span>) -> usize {
-        if let Some(itidx) = self.source_idx.iter().find(|s| s.0 == *cursor) {
-            itidx.1
+    fn source_index(
+        &mut self,
+        cursor: &Rc<Span>,
+        priorities: &HashMap<String, i32>,
+    ) -> usize {
+        if let Some(entry) = self.source_idx.iter().find(|s| s.0 == *cursor) {
+            entry.2[entry.1]
         } else {
-            self.source_idx.push((cursor.clone(), 0));
-            0
+            let eligible = eligible_source_indices(cursor, priorities);
+            let first = eligible[0];
+            self.source_idx.push((cursor.clone(), 0, eligible));
+            first
         }
     }
 
     fn advance(&mut self) -> bool {
-        while let Some((span, idx)) = self.source_idx.pop() {
-            if idx + 1 < span.sources().len() {
-                self.source_idx.push((span, idx + 1));
+        while let Some((span, pos, eligible)) = self.source_idx.pop() {
+            if pos + 1 < eligible.len() {
+                self.source_idx.push((span, pos + 1, eligible));
                 return true;
             }
         }
@@ -295,8 +374,21 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
     }
 
     pub fn eval(&self, ptrees: &ParseTrees) -> Result<ASTNode, String> {
-        let root = ptrees.0.first().expect("BUG: ParseTrees empty").clone();
-        self.eval_one(root, |_| 0)
+        // Honor priorities even for the single-tree path: pick the first
+        // eligible root, and at each ambiguous span pick the first
+        // priority-eligible source.
+        let roots = eligible_roots(&ptrees.0, &self.priorities);
+        let root = roots
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| ptrees.0.first().expect("BUG: ParseTrees empty").clone());
+        let priorities = &self.priorities;
+        self.eval_one(root, |s| {
+            eligible_source_indices(s, priorities)
+                .into_iter()
+                .next()
+                .unwrap_or(0)
+        })
     }
 
     pub fn eval_all(&self, ptrees: &ParseTrees) -> Result<Vec<ASTNode>, String> {
@@ -327,9 +419,10 @@ impl<'a, ASTNode: Clone> EarleyForest<'a, ASTNode> {
     where
         'a: 's,
     {
+        let roots = eligible_roots(&ptrees.0, &self.priorities);
         EarleyForestIter {
             forest: self,
-            roots: ptrees.0.clone().into_iter(),
+            roots: roots.into_iter(),
             state: None,
             done: false,
         }
@@ -380,9 +473,10 @@ impl<'f, 'a: 'f, ASTNode: Clone> Iterator for EarleyForestIter<'f, 'a, ASTNode> 
                 continue;
             }
             let root_clone = st.0.clone();
+            let priorities = &self.forest.priorities;
             let result = self
                 .forest
-                .eval_one(root_clone, |s| st.1.source_index(s));
+                .eval_one(root_clone, |s| st.1.source_index(s, priorities));
             self.state = Some(st);
             match result {
                 Err(e) => {

--- a/earlgrey/src/earley/trees.rs
+++ b/earlgrey/src/earley/trees.rs
@@ -5,11 +5,21 @@ use super::spans::{Span, SpanSource};
 use std::collections::HashMap;
 use std::rc::Rc;
 
+// Hard ceilings so cyclic ("bottomless") grammars fail fast with a typed
+// error instead of panicking or looping. Phase 3 will make these
+// configurable per-EarleyForest; phase 1a will add actual cycle detection
+// on the iterative path.
+const MAX_WALKER_RECURSION: u16 = 100;
+const MAX_EVAL_ONE_STEPS: usize = 100_000;
+
 pub struct EarleyForest<'a, ASTNode: Clone> {
     // Semantic actions to apply when a production is completed
     actions: HashMap<String, Box<dyn Fn(Vec<ASTNode>) -> ASTNode + 'a>>,
     // How to lift a 'scanned' terminal into an AST node.
     terminal_parser: Box<dyn Fn(&str, &str) -> ASTNode + 'a>,
+    // Per-tree walk step cap overriding MAX_EVAL_ONE_STEPS. `None` keeps
+    // the built-in safety net; `Some(n)` lets callers tighten or relax it.
+    max_steps_per_tree: Option<usize>,
 }
 
 impl<'a, ASTNode: Clone> EarleyForest<'a, ASTNode> {
@@ -17,12 +27,22 @@ impl<'a, ASTNode: Clone> EarleyForest<'a, ASTNode> {
         EarleyForest {
             actions: HashMap::new(),
             terminal_parser: Box::new(terminal_parser),
+            max_steps_per_tree: None,
         }
     }
 
     // Register semantic actions to act when rules are matched
     pub fn action(&mut self, rule: &str, action: impl Fn(Vec<ASTNode>) -> ASTNode + 'a) {
         self.actions.insert(rule.to_string(), Box::new(action));
+    }
+
+    /// Cap the number of tree-walk steps spent producing a single tree.
+    /// Overrides the library's built-in safety ceiling. When exceeded,
+    /// `eval_one` / `eval` / `eval_all` / `eval_iter` return `Err`
+    /// instead of continuing.
+    pub fn max_steps_per_tree(&mut self, max: usize) -> &mut Self {
+        self.max_steps_per_tree = Some(max);
+        self
     }
 }
 
@@ -52,19 +72,25 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
     // Recurse both spans transitively until they have no sources to follow.
     // They will return the 'scans' that happened along the way.
     // - If a span originates from a 'scan' then lift the text into an ASTNode.
-    fn walker(&self, root: &Rc<Span>) -> Result<Vec<ASTNode>, String> {
+    fn walker(&self, root: &Rc<Span>, level: u16) -> Result<Vec<ASTNode>, String> {
+        if level >= MAX_WALKER_RECURSION {
+            return Err(format!(
+                "Bottomless grammar: walker exceeded max recursion depth {}",
+                MAX_WALKER_RECURSION
+            ));
+        }
         let mut args = Vec::new();
         match root.sources().iter().next() {
             Some(SpanSource::Completion(source, trigger)) => {
-                args.extend(self.walker(source)?);
-                args.extend(self.walker(trigger)?);
+                args.extend(self.walker(source, level + 1)?);
+                args.extend(self.walker(trigger, level + 1)?);
             }
             Some(SpanSource::Scan(source, trigger)) => {
                 let symbol = source
                     .next_symbol()
                     .expect("BUG: missing scan trigger symbol")
                     .name();
-                args.extend(self.walker(source)?);
+                args.extend(self.walker(source, level + 1)?);
                 args.push((self.terminal_parser)(symbol, trigger));
             }
             None => (),
@@ -76,7 +102,7 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
     pub fn eval_recursive(&self, ptrees: &ParseTrees) -> Result<ASTNode, String> {
         // walker will always return a Vec of size 1 because root.complete
         Ok(self
-            .walker(ptrees.0.first().expect("BUG: ParseTrees empty"))?
+            .walker(ptrees.0.first().expect("BUG: ParseTrees empty"), 0)?
             .swap_remove(0))
     }
 
@@ -86,7 +112,12 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
         level: u16,
         mut explored: Vec<SpanSource>,
     ) -> Result<Vec<Vec<ASTNode>>, String> {
-        assert!(level < 100, "Bottomless grammar, stack blew up");
+        if level >= MAX_WALKER_RECURSION {
+            return Err(format!(
+                "Bottomless grammar: walker_all exceeded max recursion depth {}",
+                MAX_WALKER_RECURSION
+            ));
+        }
         let source = root.sources();
         if source.len() == 0 {
             return Ok(vec![self.reduce(root, Vec::new())?]);
@@ -200,8 +231,17 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
         let mut args = Vec::new();
         let mut completions = Vec::new();
         let mut spans = vec![root];
+        let mut steps: usize = 0;
+        let step_limit = self.max_steps_per_tree.unwrap_or(MAX_EVAL_ONE_STEPS);
 
         while let Some(cursor) = spans.pop() {
+            steps += 1;
+            if steps > step_limit {
+                return Err(format!(
+                    "Bottomless grammar: eval_one exceeded max tree-walk steps {}",
+                    step_limit
+                ));
+            }
             // As Earley chart is unwound keep a record of semantic actions to apply
             if cursor.complete() {
                 completions.push(cursor.clone());
@@ -260,17 +300,97 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
     }
 
     pub fn eval_all(&self, ptrees: &ParseTrees) -> Result<Vec<ASTNode>, String> {
-        let mut results = Vec::new();
-        for root in &ptrees.0 {
-            let mut fi = ForestIterator {
-                source_idx: Vec::new(),
+        self.eval_iter(ptrees).collect()
+    }
+
+    /// Enumerate at most `max_trees` parse trees, short-circuiting once the
+    /// cap is reached. Equivalent to `eval_iter(ptrees).take(max_trees).collect()`.
+    pub fn eval_capped(
+        &self,
+        ptrees: &ParseTrees,
+        max_trees: usize,
+    ) -> Result<Vec<ASTNode>, String> {
+        self.eval_iter(ptrees).take(max_trees).collect()
+    }
+}
+
+impl<'a, ASTNode: Clone> EarleyForest<'a, ASTNode> {
+    /// Lazy enumeration of all parse trees. Trees are produced one at a
+    /// time so callers can `.take(n)`, `.find(...)`, or stream results
+    /// without materializing the full (often combinatorial) forest.
+    ///
+    /// After an `Err` the iterator is fused and yields `None` forever.
+    pub fn eval_iter<'s>(
+        &'s self,
+        ptrees: &ParseTrees,
+    ) -> EarleyForestIter<'s, 'a, ASTNode>
+    where
+        'a: 's,
+    {
+        EarleyForestIter {
+            forest: self,
+            roots: ptrees.0.clone().into_iter(),
+            state: None,
+            done: false,
+        }
+    }
+}
+
+pub struct EarleyForestIter<'f, 'a: 'f, ASTNode: Clone> {
+    forest: &'f EarleyForest<'a, ASTNode>,
+    roots: std::vec::IntoIter<Rc<Span>>,
+    // (root span, walker state, whether eval_one still needs to run once
+    // before advance() is meaningful)
+    state: Option<(Rc<Span>, ForestIterator, bool)>,
+    done: bool,
+}
+
+impl<'f, 'a: 'f, ASTNode: Clone> Iterator for EarleyForestIter<'f, 'a, ASTNode> {
+    type Item = Result<ASTNode, String>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        loop {
+            let mut st = match self.state.take() {
+                Some(st) => st,
+                None => match self.roots.next() {
+                    None => {
+                        self.done = true;
+                        return None;
+                    }
+                    Some(r) => (
+                        r,
+                        ForestIterator {
+                            source_idx: Vec::new(),
+                        },
+                        true,
+                    ),
+                },
             };
-            let mut iterator_has_more_items = true;
-            while iterator_has_more_items {
-                results.push(self.eval_one(root.clone(), |s| fi.source_index(s))?);
-                iterator_has_more_items = fi.advance();
+            let should_yield = if st.2 {
+                st.2 = false;
+                true
+            } else {
+                st.1.advance()
+            };
+            if !should_yield {
+                // this root is exhausted; try the next one on the next loop
+                continue;
+            }
+            let root_clone = st.0.clone();
+            let result = self
+                .forest
+                .eval_one(root_clone, |s| st.1.source_index(s));
+            self.state = Some(st);
+            match result {
+                Err(e) => {
+                    self.done = true;
+                    return Some(Err(e));
+                }
+                Ok(v) => return Some(Ok(v)),
             }
         }
-        Ok(results)
     }
 }


### PR DESCRIPTION
## Summary

Implements Phase 4 of the [iterative parse-forest plan](../blob/master/docs/plans/iterative-parse-forest.md): SDF/Rascal-style rule-priority disambiguation on `EarleyForest`. Callers collapse ambiguity at the source instead of enumerating every tree and filtering afterwards.

- New API: `EarleyForest::rule_priority(rule, i32)`, keyed by the canonical `"head -> sym1 sym2"` form. Unset rules default to 0.
- Filter applies both at **root selection** (multiple start-symbol rules completing over `[0..n]`) and **within a span** (Completion backpointers whose trigger rules have different priorities). Scan sources keep priority 0 — they're not a rule choice.
- `ForestIterator` caches the per-span eligible-index list on first visit and walks that instead of the raw `sources()` vector.
- `eval()` also honors priorities: picks the first eligible root and the first priority-tied source at each ambiguous span.

Stacks on top of [#2](https://github.com/fac2003/earlgrey2/pull/2) (phases 1b/2/3). Rebase once that lands.

## Test plan

- [x] `cargo test -p earlgrey` — 54 tests pass (51 prior + 3 new)
- [x] `cargo test -p fluxcap` — 9 tests pass (no regression)
- [x] Baseline regression: ambiguous grammar with no priorities still enumerates the full Catalan(5) = 42 trees
- [x] Unmatched-paren grammar, input `( 1 )`: 3 trees → 1 tree when `'(' expr ')'` gets priority 10 and the unmatched rules get priority 1
- [x] Within-span filter: `S -> expr '$'` with the ambiguous inner `expr`, input `( 1 ) $` collapses to 1 tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)
