### PR TITLE
earlgrey: EBNF @prio(N) annotations for rule priorities (phase 5)

### DIFF
--- a/earlgrey/src/earley/grammar.rs
+++ b/earlgrey/src/earley/grammar.rs
@@ -111,6 +111,10 @@ impl fmt::Debug for Rule {
 pub struct Grammar {
     pub start: String,
     pub rules: Vec<Rc<Rule>>,
+    /// Priorities keyed by canonical `"head -> sym1 sym2 ..."` form
+    /// matching `Rule::to_string()`. Consumed by `EarleyForest` via
+    /// `with_priorities_from`. Empty by default.
+    pub rule_priorities: HashMap<String, i32>,
 }
 
 impl fmt::Debug for Grammar {
@@ -142,6 +146,7 @@ impl fmt::Debug for Grammar {
 pub struct GrammarBuilder {
     symbols: HashMap<String, Rc<Symbol>>,
     rules: Vec<Rc<Rule>>,
+    rule_priorities: HashMap<String, i32>,
     error: Option<String>,
 }
 
@@ -215,6 +220,14 @@ impl GrammarBuilder {
         self.add_rule(head, spec, true)
     }
 
+    /// Record a priority for the rule that canonicalises to
+    /// `"head -> sym1 sym2 ..."`. Does not verify the rule exists —
+    /// callers typically add it right before/after `rule_try`.
+    pub fn rule_priority_try(&mut self, head: &str, spec: &[&str], priority: i32) {
+        let key = format!("{} -> {}", head, spec.join(" "));
+        self.rule_priorities.insert(key, priority);
+    }
+
     pub fn into_grammar(mut self, start: &str) -> Result<Grammar, String> {
         let start = start.into();
         if let Some(s) = self.symbols.get(&start) {
@@ -228,6 +241,7 @@ impl GrammarBuilder {
             Ok(Grammar {
                 start,
                 rules: self.rules,
+                rule_priorities: self.rule_priorities,
             }),
             Err,
         )

--- a/earlgrey/src/earley/trees.rs
+++ b/earlgrey/src/earley/trees.rs
@@ -1,5 +1,6 @@
 #![deny(warnings)]
 
+use super::grammar::Grammar;
 use super::parser::ParseTrees;
 use super::spans::{Span, SpanSource};
 use std::collections::HashMap;
@@ -56,6 +57,16 @@ impl<'a, ASTNode: Clone> EarleyForest<'a, ASTNode> {
     /// is enumerated. Unset rules share the default priority of 0.
     pub fn rule_priority(&mut self, rule: &str, priority: i32) -> &mut Self {
         self.priorities.insert(rule.to_string(), priority);
+        self
+    }
+
+    /// Copy any `rule_priorities` that were attached to the grammar
+    /// (typically via EBNF `@prio(N)` annotations) into this forest's
+    /// priority map. Existing entries with the same key are overwritten.
+    pub fn with_priorities_from(&mut self, grammar: &Grammar) -> &mut Self {
+        for (rule, &prio) in &grammar.rule_priorities {
+            self.priorities.insert(rule.clone(), prio);
+        }
         self
     }
 }

--- a/earlgrey/src/ebnf.rs
+++ b/earlgrey/src/ebnf.rs
@@ -10,9 +10,11 @@ macro_rules! debug {
 
 #[derive(Clone, Debug)]
 enum G {
-    VariantList(Vec<Vec<String>>),
+    // Each inner entry is `(symbol-names, optional priority from @prio(N))`.
+    VariantList(Vec<(Vec<String>, Option<i32>)>),
     Variant(Vec<String>),
     Atom(String),
+    Num(i32),
     Nop,
 }
 
@@ -36,11 +38,19 @@ fn ebnf_grammar() -> Grammar {
         })
         .terminal("<Chars>", move |s| s.chars().all(|c| !c.is_control()))
         .terminal("@<Tag>", move |s| {
-            s.chars().enumerate().all(|(i, c)| {
-                i == 0 && c == '@'
-                    || i == 1 && c.is_alphabetic()
-                    || i > 1 && (c.is_alphanumeric() || c == '_')
-            })
+            // `@prio` is consumed by the priority-annotation rule below,
+            // not the generic tag rule. Exclude it here to keep the EBNF
+            // grammar unambiguous.
+            s != "@prio"
+                && s.chars().enumerate().all(|(i, c)| {
+                    i == 0 && c == '@'
+                        || i == 1 && c.is_alphabetic()
+                        || i > 1 && (c.is_alphanumeric() || c == '_')
+                })
+        })
+        .terminal("@prio", |s| s == "@prio")
+        .terminal("<Num>", |s| {
+            !s.is_empty() && s.chars().all(|c| c.is_ascii_digit())
         })
         .terminal(":=", |s| s == ":=")
         .terminal(";", |s| s == ";")
@@ -62,7 +72,15 @@ fn ebnf_grammar() -> Grammar {
         .rule("<RuleList>", &["<Rule>"])
         .rule("<Rule>", &["<Id>", ":=", "<VariantList>", ";"])
         .rule("<VariantList>", &["<VariantList>", "|", "<Variant>"])
+        .rule(
+            "<VariantList>",
+            &["<VariantList>", "|", "<Variant>", "@prio", "(", "<Num>", ")"],
+        )
         .rule("<VariantList>", &["<Variant>"])
+        .rule(
+            "<VariantList>",
+            &["<Variant>", "@prio", "(", "<Num>", ")"],
+        )
         .rule("<Variant>", &["<Variant>", "<Atom>"])
         .rule("<Variant>", &["<Atom>"])
         .rule("<Atom>", &["<Id>"])
@@ -98,6 +116,10 @@ fn ebnf_terminal_parser(
                     .borrow_mut()
                     .terminal_try(token, move |s| s == tok);
             }
+            "<Num>" => {
+                // Priority literal — lifted numerically; no grammar side effects.
+                return G::Num(token.parse().expect("BUG: <Num> tokenizer emitted non-digits"));
+            }
             _ => (),
         }
         G::Atom(token.to_string())
@@ -109,9 +131,13 @@ fn ebnf_rule_action<'a>(ev: &mut EarleyForest<'a, G>, gb: &'a RefCell<GrammarBui
         let id = pull!(G::Atom, n.remove(0));
         let body = pull!(G::VariantList, n.remove(1));
         let mut t_gb = gb.borrow_mut();
-        for rule in body {
-            debug!("Adding rule {:?} -> {:?}", id, rule);
-            t_gb.rule_try(&id, &rule.iter().map(|s| s.as_str()).collect::<Vec<&str>>());
+        for (spec, prio) in body {
+            debug!("Adding rule {:?} -> {:?} prio={:?}", id, spec, prio);
+            let spec_str: Vec<&str> = spec.iter().map(|s| s.as_str()).collect();
+            t_gb.rule_try(&id, &spec_str);
+            if let Some(p) = prio {
+                t_gb.rule_priority_try(&id, &spec_str, p);
+            }
         }
         G::Nop
     });
@@ -120,13 +146,35 @@ fn ebnf_rule_action<'a>(ev: &mut EarleyForest<'a, G>, gb: &'a RefCell<GrammarBui
 fn ebnf_variantlist_action(ev: &mut EarleyForest<'_, G>) {
     ev.action("<VariantList> -> <VariantList> | <Variant>", |mut n| {
         let mut body = pull!(G::VariantList, n.remove(0));
-        body.push(pull!(G::Variant, n.remove(1)));
+        let part = pull!(G::Variant, n.remove(1));
+        body.push((part, None));
         G::VariantList(body)
     });
+    ev.action(
+        "<VariantList> -> <VariantList> | <Variant> @prio ( <Num> )",
+        |mut n| {
+            // Spec positions: 0=VariantList 1=| 2=Variant 3=@prio 4=( 5=Num 6=)
+            // Remove highest indices first so earlier positions stay stable.
+            let prio = pull!(G::Num, n.remove(5));
+            let part = pull!(G::Variant, n.remove(2));
+            let mut body = pull!(G::VariantList, n.remove(0));
+            body.push((part, Some(prio)));
+            G::VariantList(body)
+        },
+    );
     ev.action("<VariantList> -> <Variant>", |mut n| {
         let part = pull!(G::Variant, n.remove(0));
-        G::VariantList(vec![part])
+        G::VariantList(vec![(part, None)])
     });
+    ev.action(
+        "<VariantList> -> <Variant> @prio ( <Num> )",
+        |mut n| {
+            // Spec positions: 0=Variant 1=@prio 2=( 3=Num 4=)
+            let prio = pull!(G::Num, n.remove(3));
+            let part = pull!(G::Variant, n.remove(0));
+            G::VariantList(vec![(part, Some(prio))])
+        },
+    );
 }
 
 fn ebnf_variant_action(ev: &mut EarleyForest<'_, G>) {
@@ -140,6 +188,21 @@ fn ebnf_variant_action(ev: &mut EarleyForest<'_, G>) {
     });
 }
 
+fn add_aux_variants(
+    t_gb: &mut GrammarBuilder,
+    aux: &str,
+    body: Vec<(Vec<String>, Option<i32>)>,
+) {
+    for (spec, prio) in body {
+        debug!("Adding rule {:?} -> {:?} prio={:?}", aux, spec, prio);
+        let spec_str: Vec<&str> = spec.iter().map(|s| s.as_str()).collect();
+        t_gb.rule_try(aux, &spec_str);
+        if let Some(p) = prio {
+            t_gb.rule_priority_try(aux, &spec_str, p);
+        }
+    }
+}
+
 fn ebnf_grouping_action<'a>(ev: &mut EarleyForest<'a, G>, gb: &'a RefCell<GrammarBuilder>) {
     ev.action("<Atom> -> ( <VariantList> )", move |mut n| {
         let aux = gb.borrow().unique_symbol_name();
@@ -147,13 +210,7 @@ fn ebnf_grouping_action<'a>(ev: &mut EarleyForest<'a, G>, gb: &'a RefCell<Gramma
         let mut t_gb = gb.borrow_mut();
         t_gb.nonterm_try(&aux);
         let body = pull!(G::VariantList, n.remove(1));
-        for rule in body {
-            debug!("Adding rule {:?} -> {:?}", aux, rule);
-            t_gb.rule_try(
-                &aux,
-                &rule.iter().map(|s| s.as_str()).collect::<Vec<&str>>(),
-            );
-        }
+        add_aux_variants(&mut t_gb, &aux, body);
         G::Atom(aux)
     });
     ev.action("<Atom> -> ( <VariantList> ) @<Tag>", move |mut n| {
@@ -162,13 +219,7 @@ fn ebnf_grouping_action<'a>(ev: &mut EarleyForest<'a, G>, gb: &'a RefCell<Gramma
         let mut t_gb = gb.borrow_mut();
         t_gb.nonterm_try(&aux);
         let body = pull!(G::VariantList, n.remove(1));
-        for rule in body {
-            debug!("Adding rule {:?} -> {:?}", aux, rule);
-            t_gb.rule_try(
-                &aux,
-                &rule.iter().map(|s| s.as_str()).collect::<Vec<&str>>(),
-            );
-        }
+        add_aux_variants(&mut t_gb, &aux, body);
         G::Atom(aux)
     });
 }
@@ -181,15 +232,9 @@ fn ebnf_optional_action<'a>(ev: &mut EarleyForest<'a, G>, gb: &'a RefCell<Gramma
         let mut t_gb = gb.borrow_mut();
         t_gb.nonterm_try(&aux);
         let body = pull!(G::VariantList, n.remove(1));
-        for rule in body {
-            debug!("Adding rule {:?} -> {:?}", aux, rule);
-            t_gb.rule_try(
-                &aux,
-                &rule.iter().map(|s| s.as_str()).collect::<Vec<&str>>(),
-            );
-            debug!("Adding rule {:?} -> []", aux);
-            t_gb.rule_try(&aux, &[]);
-        }
+        add_aux_variants(&mut t_gb, &aux, body);
+        debug!("Adding rule {:?} -> []", aux);
+        t_gb.rule_try(&aux, &[]);
         G::Atom(aux)
     });
     ev.action("<Atom> -> [ <VariantList> ] @<Tag>", move |mut n| {
@@ -198,15 +243,9 @@ fn ebnf_optional_action<'a>(ev: &mut EarleyForest<'a, G>, gb: &'a RefCell<Gramma
         let mut t_gb = gb.borrow_mut();
         t_gb.nonterm_try(&aux);
         let body = pull!(G::VariantList, n.remove(1));
-        for rule in body {
-            debug!("Adding rule {:?} -> {:?}", aux, rule);
-            t_gb.rule_try(
-                &aux,
-                &rule.iter().map(|s| s.as_str()).collect::<Vec<&str>>(),
-            );
-            debug!("Adding rule {:?} -> []", aux);
-            t_gb.rule_try(&aux, &[]);
-        }
+        add_aux_variants(&mut t_gb, &aux, body);
+        debug!("Adding rule {:?} -> []", aux);
+        t_gb.rule_try(&aux, &[]);
         G::Atom(aux)
     });
 }
@@ -219,16 +258,16 @@ fn ebnf_repeat_action<'a>(ev: &mut EarleyForest<'a, G>, gb: &'a RefCell<GrammarB
         let mut t_gb = gb.borrow_mut();
         t_gb.nonterm_try(&aux);
         let body = pull!(G::VariantList, n.remove(1));
-        for mut rule in body {
-            rule.push(aux.clone());
-            debug!("Adding rule {:?} -> {:?}", aux, rule);
-            t_gb.rule_try(
-                &aux,
-                &rule.iter().map(|s| s.as_str()).collect::<Vec<&str>>(),
-            );
-            debug!("Adding rule {:?} -> []", aux);
-            t_gb.rule_try(&aux, &[]);
-        }
+        let body_with_tail: Vec<(Vec<String>, Option<i32>)> = body
+            .into_iter()
+            .map(|(mut spec, prio)| {
+                spec.push(aux.clone());
+                (spec, prio)
+            })
+            .collect();
+        add_aux_variants(&mut t_gb, &aux, body_with_tail);
+        debug!("Adding rule {:?} -> []", aux);
+        t_gb.rule_try(&aux, &[]);
         G::Atom(aux)
     });
     ev.action("<Atom> -> { <VariantList> } @<Tag>", move |mut n| {
@@ -238,16 +277,16 @@ fn ebnf_repeat_action<'a>(ev: &mut EarleyForest<'a, G>, gb: &'a RefCell<GrammarB
         let mut t_gb = gb.borrow_mut();
         t_gb.nonterm_try(&aux);
         let body = pull!(G::VariantList, n.remove(1));
-        for mut rule in body {
-            rule.push(aux.clone());
-            debug!("Adding rule {:?} -> {:?}", aux, rule);
-            t_gb.rule_try(
-                &aux,
-                &rule.iter().map(|s| s.as_str()).collect::<Vec<&str>>(),
-            );
-            debug!("Adding rule {:?} -> []", aux);
-            t_gb.rule_try(&aux, &[]);
-        }
+        let body_with_tail: Vec<(Vec<String>, Option<i32>)> = body
+            .into_iter()
+            .map(|(mut spec, prio)| {
+                spec.push(aux.clone());
+                (spec, prio)
+            })
+            .collect();
+        add_aux_variants(&mut t_gb, &aux, body_with_tail);
+        debug!("Adding rule {:?} -> []", aux);
+        t_gb.rule_try(&aux, &[]);
         G::Atom(aux)
     });
 }

--- a/earlgrey/src/ebnf_test.rs
+++ b/earlgrey/src/ebnf_test.rs
@@ -365,6 +365,69 @@ fn mixed_tagged() {
 }
 
 #[test]
+fn priority_annotation_round_trip() {
+    // @prio(N) parses, attaches to the right alternative, and survives
+    // into Grammar.rule_priorities keyed by canonical rule string.
+    let g = r#"
+        expr := int
+              | "(" expr ")" @prio(10)
+              | "(" expr     @prio(1)
+              | expr ")"     @prio(1) ;
+    "#;
+    let grammar = EbnfGrammarParser::new(&g, "expr")
+        .plug_terminal("int", |i| i.chars().all(|c| c.is_ascii_digit()))
+        .into_grammar()
+        .unwrap();
+
+    assert_eq!(grammar.rule_priorities.get("expr -> ( expr )"), Some(&10));
+    assert_eq!(grammar.rule_priorities.get("expr -> ( expr"), Some(&1));
+    assert_eq!(grammar.rule_priorities.get("expr -> expr )"), Some(&1));
+    // Un-annotated alternative stays absent — treated as default (0).
+    assert!(!grammar.rule_priorities.contains_key("expr -> int"));
+}
+
+#[test]
+fn priority_annotation_collapses_forest() {
+    // End-to-end: EBNF-declared priorities feed EarleyForest via
+    // with_priorities_from and collapse an ambiguous paren forest.
+    let g = r#"
+        expr := int
+              | "(" expr ")" @prio(10)
+              | "(" expr     @prio(1)
+              | expr ")"     @prio(1) ;
+    "#;
+    let grammar = EbnfGrammarParser::new(&g, "expr")
+        .plug_terminal("int", |i| i.chars().all(|c| c.is_ascii_digit()))
+        .into_grammar()
+        .unwrap();
+
+    // Without priorities: ambiguous.
+    let ef_plain = EarleyForest::new(|sym, tok| Tree::Leaf(sym.to_string(), tok.to_string()));
+    let mut ef_plain = ef_plain;
+    for rule in grammar.rules.iter().map(|r| r.to_string()) {
+        ef_plain.action(&rule.clone(), move |nodes| Tree::Node(rule.clone(), nodes));
+    }
+    let parser = EarleyParser::new(grammar.clone());
+    let pout = parser.parse(["(", "1", ")"].iter()).unwrap();
+    assert!(
+        ef_plain.eval_all(&pout).unwrap().len() >= 2,
+        "paren grammar should be ambiguous before priorities are wired"
+    );
+
+    // With priorities: forest collapses to one tree.
+    let mut ef = EarleyForest::new(|sym, tok| Tree::Leaf(sym.to_string(), tok.to_string()));
+    for rule in grammar.rules.iter().map(|r| r.to_string()) {
+        ef.action(&rule.clone(), move |nodes| Tree::Node(rule.clone(), nodes));
+    }
+    ef.with_priorities_from(&grammar);
+    assert_eq!(
+        ef.eval_all(&pout).unwrap().len(),
+        1,
+        "with_priorities_from should collapse the ambiguity"
+    );
+}
+
+#[test]
 fn plug_terminal() {
     use std::str::FromStr;
     let g = r#"

--- a/earlgrey/src/ebnf_tokenizer.rs
+++ b/earlgrey/src/ebnf_tokenizer.rs
@@ -68,6 +68,17 @@ impl<I: Iterator<Item = char>> EbnfTokenizer<I> {
                 }
                 Ok(Some(id))
             }
+            // Digit runs (used by priority annotations: `@prio ( 10 )`).
+            Some(x) if x.is_ascii_digit() => {
+                let mut num = x.to_string();
+                while let Some(ch) = self.input.peek() {
+                    if !ch.is_ascii_digit() {
+                        break;
+                    }
+                    num.push(self.input.next().unwrap());
+                }
+                Ok(Some(num))
+            }
             // Swallow whitespace.
             Some(x) if x.is_whitespace() => {
                 while let Some(ws) = self.input.peek() {
@@ -136,5 +147,16 @@ mod tests {
         for (idx, token) in EbnfTokenizer::new(input.chars()).enumerate() {
             assert_eq!(token, expected[idx]);
         }
+    }
+
+    #[test]
+    fn priority_annotation() {
+        // `@prio(10)` is tokenized as `@prio`, `(`, `10`, `)`.
+        let input = r#"expr := foo @prio(10) | bar ;"#;
+        let expected = vec![
+            "expr", ":=", "foo", "@prio", "(", "10", ")", "|", "bar", ";",
+        ];
+        let toks: Vec<_> = EbnfTokenizer::new(input.chars()).collect();
+        assert_eq!(toks, expected);
     }
 }


### PR DESCRIPTION
## Summary

Implements Phase 5 of the [iterative parse-forest plan](../blob/master/docs/plans/iterative-parse-forest.md): inline EBNF `@prio(N)` annotations for rule priorities, so grammars declare disambiguation at their definition site instead of registering rule strings on `EarleyForest` programmatically.

```
expr := int
      | "(" expr ")" @prio(10)
      | "(" expr     @prio(1)
      | expr ")"     @prio(1) ;
```

- Tokenizer emits digit-only tokens so priority literals reach the parser as distinct tokens.
- EBNF grammar adds `@prio` as a dedicated terminal (excluded from the generic `@<Tag>` predicate to keep the grammar unambiguous) and `<Num>` for the numeric argument. Two new variant-list rules attach `@prio(N)` to the preceding alternative — both the lone-variant and the `| <Variant>` continuation cases.
- Variant tuples now track `Option<i32>` priority alongside the spec. A shared `add_aux_variants` helper forwards priorities through the `[ ]` / `{ }` / `( )` desugaring so annotations survive auxiliary non-terminal introduction.
- `Grammar` and `GrammarBuilder` carry a `rule_priorities: HashMap<String, i32>` map keyed by the canonical `"head -> sym1 sym2"` form. `EarleyForest::with_priorities_from(&grammar)` wires it in one call.

Stacks on [#3](https://github.com/fac2003/earlgrey2/pull/3) (phase 4). Rebase once that lands.

## Test plan

- [x] `cargo test -p earlgrey` — 57 tests pass (54 prior + 3 new)
- [x] `cargo test -p fluxcap` — 9 tests pass (no regression)
- [x] Tokenizer: `expr := foo @prio(10) | bar ;` tokenizes to the expected 10-token sequence
- [x] Grammar round-trip: `@prio(N)` attaches to the right alternative and appears in `grammar.rule_priorities` keyed by the rule's canonical form
- [x] End-to-end: paren grammar with EBNF-declared priorities collapses `( 1 )` from 3 trees to 1 via `with_priorities_from`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
