### PR TITLE
earlgrey 0.5.0: typed ForestWalkError on eval_* surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "earlgrey"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "lexers",
  "rustyline 14.0.0",

--- a/earlgrey/Cargo.toml
+++ b/earlgrey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "earlgrey"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 license = "MIT"
 authors = ["Rodolfo Granata <warlock.cc@gmail.com>"]

--- a/earlgrey/src/earley/mod.rs
+++ b/earlgrey/src/earley/mod.rs
@@ -8,7 +8,7 @@ mod spans;
 pub use parser::EarleyParser;
 
 mod trees;
-pub use trees::EarleyForest;
+pub use trees::{EarleyForest, ForestWalkError};
 
 #[cfg(test)]
 mod parser_test;

--- a/earlgrey/src/earley/parser_test.rs
+++ b/earlgrey/src/earley/parser_test.rs
@@ -2,7 +2,7 @@
 
 use super::grammar::{Grammar, GrammarBuilder};
 use super::parser::EarleyParser;
-use super::trees::EarleyForest;
+use super::trees::{EarleyForest, ForestWalkError};
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -265,7 +265,12 @@ fn earley_bottomless() {
         .eval_all(&pout)
         .expect_err("iterative eval_all should surface a bottomless-grammar error");
     assert!(
-        err.contains("Bottomless grammar"),
+        matches!(err, ForestWalkError::StepCapExceeded { .. }),
+        "unexpected error variant: {:?}",
+        err
+    );
+    assert!(
+        err.to_string().contains("Bottomless grammar"),
         "unexpected error: {}",
         err
     );
@@ -503,10 +508,83 @@ fn max_steps_per_tree_triggers_error() {
         .eval(&pout)
         .expect_err("tight step cap should return Err");
     assert!(
-        err.contains("max tree-walk steps"),
+        matches!(
+            err,
+            ForestWalkError::StepCapExceeded {
+                caller_configured: true,
+                limit: 1,
+            }
+        ),
+        "unexpected error variant: {:?}",
+        err
+    );
+    assert!(
+        err.to_string().contains("max tree-walk steps"),
         "unexpected error: {}",
         err
     );
+}
+
+#[test]
+fn step_cap_default_reports_not_caller_configured() {
+    // The built-in safety ceiling firing (i.e. no `max_steps_per_tree`
+    // call) must surface as `caller_configured: false` so downstream
+    // consumers can route the two cases differently.
+    let grammar = GrammarBuilder::default()
+        .nonterm("E")
+        .nonterm("A")
+        .terminal("n", |n| n == "n")
+        .rule("E", &["A"])
+        .rule("A", &["E"])
+        .rule("A", &["n"])
+        .into_grammar("E")
+        .expect("Bad grammar");
+    let p = EarleyParser::new(grammar.clone());
+    let pout = p.parse("n".split_whitespace()).unwrap();
+    let ef = tree_evaler(grammar);
+
+    // Iterator will yield the finite tree(s) then error on a cyclic path.
+    let mut saw_step_cap = None;
+    for r in ef.eval_iter(&pout) {
+        if let Err(e) = r {
+            saw_step_cap = Some(e);
+            break;
+        }
+    }
+    let err = saw_step_cap.expect("expected a step-cap error from cyclic grammar");
+    assert!(
+        matches!(
+            err,
+            ForestWalkError::StepCapExceeded {
+                caller_configured: false,
+                ..
+            }
+        ),
+        "expected caller_configured=false for default cap, got: {:?}",
+        err
+    );
+}
+
+#[test]
+fn missing_action_returns_typed_variant() {
+    // An `EarleyForest` without an `action` registered for the head rule
+    // surfaces a typed `MissingAction` variant, not a stringified error.
+    let grammar = GrammarBuilder::default()
+        .nonterm("E")
+        .terminal("n", |n| n == "n")
+        .rule("E", &["n"])
+        .into_grammar("E")
+        .expect("Bad grammar");
+    let p = EarleyParser::new(grammar.clone());
+    let pout = p.parse("n".split_whitespace()).unwrap();
+    // Build a forest that has the terminal_parser but no rule actions.
+    let ef: EarleyForest<Tree> =
+        EarleyForest::new(|sym, tok| Tree::Leaf(sym.to_string(), tok.to_string()));
+    let err = ef.eval(&pout).expect_err("no rule action registered");
+    match err {
+        ForestWalkError::MissingAction { rule } => assert_eq!(rule, "E -> n"),
+        other => panic!("expected MissingAction, got {:?}", other),
+    }
 }
 
 #[test]

--- a/earlgrey/src/earley/trees.rs
+++ b/earlgrey/src/earley/trees.rs
@@ -13,6 +13,63 @@ use std::rc::Rc;
 const MAX_WALKER_RECURSION: u16 = 100;
 const MAX_EVAL_ONE_STEPS: usize = 100_000;
 
+/// Typed error returned from the public `eval_*` surface of
+/// [`EarleyForest`]. Lets callers distinguish a recoverable step-cap hit
+/// from a genuinely broken ("bottomless") grammar without string-matching
+/// on the `Display` form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ForestWalkError {
+    /// The recursive walker (`eval_recursive` / `eval_all_recursive`)
+    /// exceeded `MAX_WALKER_RECURSION`. Indicates a cyclic grammar.
+    BottomlessRecursion { limit: u16 },
+
+    /// The iterative walker (`eval` / `eval_all` / `eval_iter` /
+    /// `eval_capped`) hit its per-tree step ceiling. May be a cyclic
+    /// grammar (when `max_steps_per_tree` is at the default) or a
+    /// legitimately deep parse that hit the caller's configured cap.
+    StepCapExceeded { limit: usize, caller_configured: bool },
+
+    /// Missing semantic action for a completed rule.
+    MissingAction { rule: String },
+
+    /// Fallback for any other string-shaped error the crate surfaces
+    /// internally (kept for forward-compatibility; prefer typed variants
+    /// when adding new errors).
+    Other(String),
+}
+
+impl std::fmt::Display for ForestWalkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ForestWalkError::BottomlessRecursion { limit } => write!(
+                f,
+                "Bottomless grammar: walker exceeded max recursion depth {}",
+                limit
+            ),
+            ForestWalkError::StepCapExceeded { limit, .. } => write!(
+                f,
+                "Bottomless grammar: eval_one exceeded max tree-walk steps {}",
+                limit
+            ),
+            ForestWalkError::MissingAction { rule } => {
+                write!(f, "Missing Action: {}", rule)
+            }
+            ForestWalkError::Other(s) => f.write_str(s),
+        }
+    }
+}
+
+impl std::error::Error for ForestWalkError {}
+
+// Soft-compat for existing consumers whose call chains still propagate
+// `String` errors via `?`. Lets them keep compiling without an explicit
+// `.map_err(...)` at every site; new code should prefer the typed variant.
+impl From<ForestWalkError> for String {
+    fn from(e: ForestWalkError) -> Self {
+        e.to_string()
+    }
+}
+
 pub struct EarleyForest<'a, ASTNode: Clone> {
     // Semantic actions to apply when a production is completed
     actions: HashMap<String, Box<dyn Fn(Vec<ASTNode>) -> ASTNode + 'a>>,
@@ -130,7 +187,11 @@ fn eligible_roots(
 }
 
 impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
-    fn reduce(&self, root: &Rc<Span>, args: Vec<ASTNode>) -> Result<Vec<ASTNode>, String> {
+    fn reduce(
+        &self,
+        root: &Rc<Span>,
+        args: Vec<ASTNode>,
+    ) -> Result<Vec<ASTNode>, ForestWalkError> {
         // If span is not complete, reduce is a noop passthrough
         if !root.complete() {
             return Ok(args);
@@ -138,7 +199,7 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
         // Lookup semantic action to apply based on rule name
         let rulename = root.rule.to_string();
         match self.actions.get(&rulename) {
-            None => Err(format!("Missing Action: {}", rulename)),
+            None => Err(ForestWalkError::MissingAction { rule: rulename }),
             Some(action) => {
                 if cfg!(feature = "debug") {
                     eprintln!("Reduction: {}", rulename);
@@ -155,12 +216,15 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
     // Recurse both spans transitively until they have no sources to follow.
     // They will return the 'scans' that happened along the way.
     // - If a span originates from a 'scan' then lift the text into an ASTNode.
-    fn walker(&self, root: &Rc<Span>, level: u16) -> Result<Vec<ASTNode>, String> {
+    fn walker(
+        &self,
+        root: &Rc<Span>,
+        level: u16,
+    ) -> Result<Vec<ASTNode>, ForestWalkError> {
         if level >= MAX_WALKER_RECURSION {
-            return Err(format!(
-                "Bottomless grammar: walker exceeded max recursion depth {}",
-                MAX_WALKER_RECURSION
-            ));
+            return Err(ForestWalkError::BottomlessRecursion {
+                limit: MAX_WALKER_RECURSION,
+            });
         }
         let mut args = Vec::new();
         match root.sources().iter().next() {
@@ -182,7 +246,7 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
     }
 
     // for non-ambiguous grammars this retreieves the only possible parse
-    pub fn eval_recursive(&self, ptrees: &ParseTrees) -> Result<ASTNode, String> {
+    pub fn eval_recursive(&self, ptrees: &ParseTrees) -> Result<ASTNode, ForestWalkError> {
         // walker will always return a Vec of size 1 because root.complete
         Ok(self
             .walker(ptrees.0.first().expect("BUG: ParseTrees empty"), 0)?
@@ -194,12 +258,11 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
         root: &Rc<Span>,
         level: u16,
         mut explored: Vec<SpanSource>,
-    ) -> Result<Vec<Vec<ASTNode>>, String> {
+    ) -> Result<Vec<Vec<ASTNode>>, ForestWalkError> {
         if level >= MAX_WALKER_RECURSION {
-            return Err(format!(
-                "Bottomless grammar: walker_all exceeded max recursion depth {}",
-                MAX_WALKER_RECURSION
-            ));
+            return Err(ForestWalkError::BottomlessRecursion {
+                limit: MAX_WALKER_RECURSION,
+            });
         }
         let source = root.sources();
         if source.len() == 0 {
@@ -240,7 +303,10 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
     }
 
     // Retrieves all parse trees
-    pub fn eval_all_recursive(&self, ptrees: &ParseTrees) -> Result<Vec<ASTNode>, String> {
+    pub fn eval_all_recursive(
+        &self,
+        ptrees: &ParseTrees,
+    ) -> Result<Vec<ASTNode>, ForestWalkError> {
         let mut trees = Vec::new();
         for root in &ptrees.0 {
             trees.extend(
@@ -317,20 +383,21 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
         &self,
         root: Rc<Span>,
         mut selector: impl FnMut(&Rc<Span>) -> usize,
-    ) -> Result<ASTNode, String> {
+    ) -> Result<ASTNode, ForestWalkError> {
         let mut args = Vec::new();
         let mut completions = Vec::new();
         let mut spans = vec![root];
         let mut steps: usize = 0;
+        let caller_configured = self.max_steps_per_tree.is_some();
         let step_limit = self.max_steps_per_tree.unwrap_or(MAX_EVAL_ONE_STEPS);
 
         while let Some(cursor) = spans.pop() {
             steps += 1;
             if steps > step_limit {
-                return Err(format!(
-                    "Bottomless grammar: eval_one exceeded max tree-walk steps {}",
-                    step_limit
-                ));
+                return Err(ForestWalkError::StepCapExceeded {
+                    limit: step_limit,
+                    caller_configured,
+                });
             }
             // As Earley chart is unwound keep a record of semantic actions to apply
             if cursor.complete() {
@@ -357,7 +424,9 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
                 let action = self
                     .actions
                     .get(&rulename)
-                    .ok_or(format!("Missing Action: {}", rulename))?;
+                    .ok_or_else(|| ForestWalkError::MissingAction {
+                        rule: rulename.clone(),
+                    })?;
                 args.push(action(rule_args));
             } else {
                 let span_source_idx = selector(&cursor);
@@ -384,7 +453,7 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
         Ok(args.pop().expect("BUG: mismatched reduce args"))
     }
 
-    pub fn eval(&self, ptrees: &ParseTrees) -> Result<ASTNode, String> {
+    pub fn eval(&self, ptrees: &ParseTrees) -> Result<ASTNode, ForestWalkError> {
         // Honor priorities even for the single-tree path: pick the first
         // eligible root, and at each ambiguous span pick the first
         // priority-eligible source.
@@ -402,7 +471,7 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
         })
     }
 
-    pub fn eval_all(&self, ptrees: &ParseTrees) -> Result<Vec<ASTNode>, String> {
+    pub fn eval_all(&self, ptrees: &ParseTrees) -> Result<Vec<ASTNode>, ForestWalkError> {
         self.eval_iter(ptrees).collect()
     }
 
@@ -412,7 +481,7 @@ impl<ASTNode: Clone> EarleyForest<'_, ASTNode> {
         &self,
         ptrees: &ParseTrees,
         max_trees: usize,
-    ) -> Result<Vec<ASTNode>, String> {
+    ) -> Result<Vec<ASTNode>, ForestWalkError> {
         self.eval_iter(ptrees).take(max_trees).collect()
     }
 }
@@ -450,7 +519,7 @@ pub struct EarleyForestIter<'f, 'a: 'f, ASTNode: Clone> {
 }
 
 impl<'f, 'a: 'f, ASTNode: Clone> Iterator for EarleyForestIter<'f, 'a, ASTNode> {
-    type Item = Result<ASTNode, String>;
+    type Item = Result<ASTNode, ForestWalkError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.done {

--- a/earlgrey/src/ebnf_test.rs
+++ b/earlgrey/src/ebnf_test.rs
@@ -27,7 +27,10 @@ where
     }
 
     let parser = EarleyParser::new(grammar);
-    Ok(move |tokenizer| tree_builder.eval_all(&parser.parse(tokenizer)?))
+    Ok(move |tokenizer| {
+        let pt = parser.parse(tokenizer)?;
+        tree_builder.eval_all(&pt).map_err(Into::into)
+    })
 }
 
 fn check_trees<T: fmt::Debug>(trees: &Vec<T>, expected: Vec<&str>) {

--- a/earlgrey/src/lib.rs
+++ b/earlgrey/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 
 mod earley;
-pub use earley::{EarleyForest, EarleyParser, Grammar, GrammarBuilder};
+pub use earley::{EarleyForest, EarleyParser, ForestWalkError, Grammar, GrammarBuilder};
 
 mod ebnf;
 mod ebnf_tokenizer;

--- a/earlgrey/src/parsers.rs
+++ b/earlgrey/src/parsers.rs
@@ -58,5 +58,8 @@ where
     }
 
     let parser = EarleyParser::new(grammar);
-    Ok(move |tokenizer| tree_builder.eval_all(&parser.parse(tokenizer)?))
+    Ok(move |tokenizer| {
+        let pt = parser.parse(tokenizer)?;
+        tree_builder.eval_all(&pt).map_err(Into::into)
+    })
 }

--- a/fluxcap/Cargo.toml
+++ b/fluxcap/Cargo.toml
@@ -9,5 +9,5 @@ repository = "https://github.com/rodolf0/tox"
 
 [dependencies]
 chrono = "0.4"
-earlgrey = { version = "0.4", path = "../earlgrey" }
+earlgrey = { version = "0.5", path = "../earlgrey" }
 kronos = { version = "0.1", path = "../kronos" }

--- a/numerica/Cargo.toml
+++ b/numerica/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-earlgrey = { version = "0.4", path = "../earlgrey" }
+earlgrey = { version = "0.5", path = "../earlgrey" }
 rand_distr = "0.5"
 rand = "0.9"


### PR DESCRIPTION
## Summary

Closes #5 — introduces a typed `ForestWalkError` on the public `eval_*` surface of `EarleyForest`, replacing the ad-hoc `Result<_, String>` returns. Consumers (notably transformix-2) can now pattern-match on the failure mode instead of string-matching the `Display` form. Bumps `earlgrey` to `0.5.0` (breaking).

## What changed

- New `ForestWalkError` enum in `earlgrey/src/earley/trees.rs`:
  - `BottomlessRecursion { limit: u16 }` — recursive walker hit `MAX_WALKER_RECURSION`. Always a cyclic grammar.
  - `StepCapExceeded { limit: usize, caller_configured: bool }` — iterative walker hit its per-tree step ceiling. `caller_configured: true` when `max_steps_per_tree(_)` was set, `false` when the built-in safety net fired. Lets callers route the caller-set cap case (recoverable — preserve previous AST) differently from a cyclic-grammar bug.
  - `MissingAction { rule: String }` — no semantic action registered for a completed rule.
  - `Other(String)` — forward-compat escape hatch for future string-shaped errors.
- `impl Display + std::error::Error` on the enum; `Display` reproduces the existing error strings so log-only consumers see no change.
- `impl From<ForestWalkError> for String` — pragmatic bridge so existing String-returning call chains (`sexpr_parser`, `ast_parser`, `EbnfGrammarParser::into_grammar`) keep compiling with a small `.map_err(Into::into)`.
- Signature changes on public methods:
  - `eval`, `eval_all`, `eval_capped`, `eval_recursive`, `eval_all_recursive`, `eval_iter` — now `Result<_, ForestWalkError>`.
- Workspace: path-dep users (`fluxcap`, `numerica`) pinned to `earlgrey = "0.5"`.

## Tests

- Existing bottomless-grammar tests updated to assert the typed variant alongside the Display string (still asserts `"Bottomless grammar"` substring).
- New `step_cap_default_reports_not_caller_configured` — confirms the built-in safety net surfaces `caller_configured: false` while a user-set cap surfaces `caller_configured: true`.
- New `missing_action_returns_typed_variant` — confirms missing rule actions produce `ForestWalkError::MissingAction { rule }` instead of a stringified error.
- All 59 `cargo test -p earlgrey` tests pass; `fluxcap` and `numerica` downstream test suites pass unchanged.

## Test plan

- [x] `cargo test -p earlgrey`
- [x] `cargo test -p fluxcap -p numerica`
- [ ] Publish `earlgrey 0.5.0` to crates.io after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
